### PR TITLE
Fix withEntry

### DIFF
--- a/lib/withEntry.js
+++ b/lib/withEntry.js
@@ -54,11 +54,11 @@ const withEntry = asClassMixin((Class) => {
       } catch (e) {
         entryErrors.set(this.catchEntryError(e))
         throw Object.assign(
-          new TheError(`[processEntry]${e.message}`, {
+          new TheError(`[processEntry]${e.message}`), {
             ...e,
             detail: { values },
             resolved: true,
-          })
+          }
         )
       }
     },


### PR DESCRIPTION
@okunishinishi 
Object.assign の意図通りになっていないため、processEntry で失敗したあとのエラーが `resolved: true` にならないなどの問題がある（そうするとrescueで拾われる）